### PR TITLE
Removed the static lookup code from critical path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ test: binsearch_lookup_test.bin string_funs_test.bin env_parser_test.bin dynamic
 	./binsearch_lookup_test.bin
 	./string_funs_test.bin
 	./env_parser_test.bin
-	python test/dynamic_lookup_test.py
-	python test/integration_tests.py
+	python3 test/dynamic_lookup_test.py
+	python3 test/integration_tests.py
 
 rtld_loader.so: $(shell find src -type f) src/lookup_by_channel.generated.c
 	gcc -shared -nostdlib -fno-stack-protector -fPIC -O2 src/*.c -o rtld_loader.so

--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ The Replit RTLD Loader allows dynamically loaded shared libraries (.so)
 to work seamlessly in Repls. It uses
 the [rtld-audit API](https://man7.org/linux/man-pages/man7/rtld-audit.7.html)
 to observe a process' library loading activity to learn which Nix channel
-the binary was built from (if any), and then resolves dynamic libraries loading requests
-for the process from a list of known Nix packages from the matching Nix channel to make sure
-they are compatible. It is a better alternative than using `LD_LIBRARY_PATH` because:
+the binary was built from (if any), and then uses REPLIT_LD_LIBRARY_PATH variable to resolve
+libraries. It is a better alternative than using `LD_LIBRARY_PATH` because:
 
 1. rather than overriding the default behavior of the system loader, it acts as a fallback
 2. it is aware of how Nix-built binaries work
@@ -19,9 +18,7 @@ for more background.
 1. Activate the loader via the LD_AUDIT variable when running a program, ex: `LD_AUDIT=rtld_loader.so python main.py`
 2. The loader will observe which `libc.so` is loaded when the program runs based on the la_objopen hook. If it is
    from a known Nix path, we'll use it to infer the Nix channel the program was built from.
-3. If the program is unable to load a required shared object library by itself, it will fall back to the loader, which
-   perform a lookup based on a known list of .so files from Nix packages from the same Nix channel as the program.
-4. If the above lookup does not return anything, it will also search the directory paths within `REPLIT_LD_LIBRARY_PATH`
+3. If the system loader fails locate the library, it will also search the directory paths within `REPLIT_LD_LIBRARY_PATH`
    for a matching library.
 
 ## Logging

--- a/src/rtld_loader.c
+++ b/src/rtld_loader.c
@@ -17,7 +17,6 @@ https://man7.org/linux/man-pages/man7/rtld-audit.7.html
 #include "string_funs.h"
 #include "syscalls.h"
 
-static int nix_channel = CHANNEL_UNKNOWN;
 static char replit_ld_library_path[MAX_LD_LIBRARY_PATH_LENGTH] = {0};
 
 __attribute__((constructor)) static void init(void) {
@@ -49,15 +48,6 @@ char* la_objsearch(const char* name, uintptr_t* cookie, unsigned int flag) {
       log_info(libname);
       log_info("\n  searching...\n");
       const char* result = NULL;
-      if (nix_channel != CHANNEL_UNKNOWN) {
-        result = lookup_by_channel(nix_channel, libname);
-        if (result != NULL) {
-          log_info("  found statically: ");
-          log_info(result);
-          log_info("\n");
-          return (char*)result;
-        }
-      }
       if (result == NULL) {
         result = dynamic_lookup(libname, replit_ld_library_path);
         if (result != NULL) {
@@ -71,21 +61,6 @@ char* la_objsearch(const char* name, uintptr_t* cookie, unsigned int flag) {
     }
   }
   return (char*)name;
-}
-
-unsigned int la_objopen(struct link_map* map, Lmid_t lmid, uintptr_t* cookie) {
-  log_debug("la_objopen(");
-  log_debug(map->l_name);
-  log_debug(")\n");
-  if (nix_channel == CHANNEL_UNKNOWN) {
-    nix_channel = get_nix_channel(map->l_name);
-    if (nix_channel != CHANNEL_UNKNOWN) {
-      log_info("Found Nix channel: ");
-      log_info(nix_channel_str(nix_channel));
-      log_info("\n");
-    }
-  }
-  return 0;
 }
 
 void la_preinit(uintptr_t* cookie) {

--- a/test/integration_tests.py
+++ b/test/integration_tests.py
@@ -7,50 +7,13 @@ rtld_env = {
   "REPLIT_RTLD_LOG_LEVEL": "2"
 }
 python_23_11 = '/nix/store/2miairdnqbrsjlcllj2vypnvmk2k9z6j-python3-3.10.13'
-python_22_11 = '/nix/store/hd4cc9rh83j291r5539hkf6qd8lgiikb-python3-3.10.8'
-cairo_23_11 = '/nix/store/b6b71vq4ahf6habxzk8ajkizq0f3hiln-cairo-1.18.0'
-cairo_22_11 = '/nix/store/72mqxxhh3cy5yifh92wh2yb8cl2hikyy-cairo-1.16.0'
 ace = '/nix/store/mk39yjfi7n0z9qy0wv56pg696y1aj3d8-ace-7.0.8/'
 
 def realize(pkgpath):
   subprocess.run(['nix-store', '-r', pkgpath], stderr=subprocess.PIPE, stdout=subprocess.PIPE)
 
 realize(python_23_11)
-realize(python_22_11)
-realize(cairo_23_11)
-realize(cairo_22_11)
 realize(ace)
-
-def test_cairo_23_11():
-  code = "import ctypes; print(ctypes.cdll.LoadLibrary('libcairo.so'))"
-  output = subprocess.check_output(
-    ["%s/bin/python" % python_23_11, '-c', code],
-    env = rtld_env
-  )
-  
-  assert str(output, 'UTF-8').startswith("<CDLL 'libcairo.so'")
-  
-  with open("%s/rtld_loader.log" % pwd) as f:
-    log_content = f.read()
-    assert ('found statically: %s' % cairo_23_11) in log_content
-
-  print('OK test_cairo_23_11')
-
-def test_cairo_22_11():
-  code = "import ctypes; print(ctypes.cdll.LoadLibrary('libcairo.so'))"
-
-  output = subprocess.check_output(
-    ["%s/bin/python" % python_22_11, '-c', code],
-    env = rtld_env
-  )
-
-  assert str(output, 'UTF-8').startswith("<CDLL 'libcairo.so'")
-
-  with open("%s/rtld_loader.log" % pwd) as f:
-    log_content = f.read()
-    assert ('found statically: %s' % cairo_22_11) in log_content
-
-  print('OK test_cairo_22_11')
 
 def test_ace_dynamic():
   code = "import ctypes; print(ctypes.cdll.LoadLibrary('libACE_ETCL.so'))"
@@ -60,13 +23,11 @@ def test_ace_dynamic():
     'REPLIT_LD_LIBRARY_PATH': '%s/lib' % ace
   })
   output = subprocess.check_output(
-    ["%s/bin/python" % python_22_11, '-c', code],
+    ["%s/bin/python" % python_23_11, '-c', code],
     env = env
   )
   
   assert str(output, 'UTF-8').startswith("<CDLL 'libACE_ETCL.so'")
   print('OK test_ace_dynamic')
 
-test_cairo_23_11()
-test_cairo_22_11()
 test_ace_dynamic()


### PR DESCRIPTION
# Why

We found that there's currently not a practical way to make the cacache disk available in deployments, so we are going to disable the static channel-based look up for now. Relying on REPLIT_LD_LIBRARY_PATH only will still be beneficial if the follow hypothesis is true:
* as long as the Nix channel of the entrypoint binary (python3 or node) is later than the Nix channel of a dynamically loaded shared object, the likelihood of breakage is low.

So test cases have shown this to be true. I plan to conduct some experiments to test this more.

## Changes

1. Removed call to lookup_by_channel
2. Removed code for dynamic Nix channel detection.
3. Updated integration test to match