### PR TITLE
don't relink /nix/store paths

### DIFF
--- a/src/rtld_loader.c
+++ b/src/rtld_loader.c
@@ -39,7 +39,7 @@ char* la_objsearch(const char* name, uintptr_t* cookie, unsigned int flag) {
   log_debug(", ");
   log_debug_int(flag);
   log_debug(")\n");
-  if (flag == LA_SER_DEFAULT) {
+  if (flag == LA_SER_DEFAULT && strncmp(name, "/nix/store", 10) != 0) {
     char* libname = my_strrchr(name, '/');
     if (libname != NULL) {
       libname++;  // advance past the /


### PR DESCRIPTION
Why
===

Some programs are broken when there `/nix/store/...../lib/library.so` libs are attempted and relinked to other versions of the library. We should always honor nix store library paths.

What changed
============

No longer try to relink libraries set to /nix/store

Test plan
=========

Test on dynamic executables from external sources to confirm that regular functionality is not broken.

Rollout
=======

<!-- Describe any procedures or requirements needed to roll this out safely (or check the box below) -->

- [ ] This is fully backward and forward compatible
