### PR TITLE
Remove python from build inputs; bump devShell to python312

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
       pname = "replit_rtld_loader";
       version = "1";
       src = ./.;
-      buildInputs = [pkgs.python310];
+      buildInputs = [];
       installPhase = ''
         mkdir $out
         mv rtld_loader.so $out/
@@ -21,7 +21,7 @@
       packages.x86_64-linux.default = package;
       devShells.x86_64-linux.default = pkgs.mkShell {
         packages = with pkgs; [
-          python310
+          python312
           gnumake
         ];
       };

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
       packages.x86_64-linux.default = package;
       devShells.x86_64-linux.default = pkgs.mkShell {
         packages = with pkgs; [
-          python312
+          python314
           gnumake
         ];
       };

--- a/replit.nix
+++ b/replit.nix
@@ -2,7 +2,7 @@
 {pkgs}: {
   deps = [
     pkgs.gdb
-    pkgs.python314Full
+    pkgs.python314
     pkgs.clang
   ];
 }

--- a/replit.nix
+++ b/replit.nix
@@ -2,7 +2,7 @@
 {pkgs}: {
   deps = [
     pkgs.gdb
-    pkgs.python310Full
+    pkgs.python312Full
     pkgs.clang
   ];
 }

--- a/replit.nix
+++ b/replit.nix
@@ -2,7 +2,7 @@
 {pkgs}: {
   deps = [
     pkgs.gdb
-    pkgs.python312Full
+    pkgs.python314Full
     pkgs.clang
   ];
 }

--- a/scripts/ci_check.sh
+++ b/scripts/ci_check.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p clang python314Full gnumake
+#! nix-shell -i bash -p clang python314 gnumake
 
 set -e
 

--- a/scripts/ci_check.sh
+++ b/scripts/ci_check.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p clang python310Full gnumake
+#! nix-shell -i bash -p clang python312Full gnumake
 
 set -e
 

--- a/scripts/ci_check.sh
+++ b/scripts/ci_check.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p clang python312Full gnumake
+#! nix-shell -i bash -p clang python314Full gnumake
 
 set -e
 


### PR DESCRIPTION
Blocking https://github.com/replit/nixmodules/pull/479

## Summary
- Remove `python310` from `buildInputs` — it's not needed to build `rtld_loader.so` (pure C, `gcc -shared -nostdlib`)
- Bump devShell python from `python310` to `python312`

## Why
Consumers like `nixmodules` that use `inputs.replit-rtld-loader.inputs.nixpkgs.follows = "nixpkgs"` break when their nixpkgs points to unstable, where `python310` has been removed. Since Python is only used for tests (not the build), it shouldn't be in `buildInputs` at all.

## Test plan
The build produces `rtld_loader.so` using only gcc with no Python dependency — removing it from `buildInputs` is a no-op for the build output.

~ written by Zerg 👾